### PR TITLE
Fix indexing for DIRECTORY_ENTRIES in the BlockDevWrite function

### DIFF
--- a/src/blockdev_flash.c
+++ b/src/blockdev_flash.c
@@ -34,7 +34,7 @@ int BlockDevWrite(uint32_t dwAddress, uint8_t * pbBuf) {
         debug("Modifying directory entry %d", ((BOOT_SECT_SIZE + FAT_SIZE +
                     ROOT_DIR_SIZE) - offset) % DIRECTORY_ENTRY_SIZE);
 
-        for(uint32_t i = 0; i < BLOCKSIZE; i++) {
+        for(uint32_t i = 0; i < DIRECTORY_ENTRY_SIZE; i++) {
             ((uint8_t*)&DIRECTORY_ENTRIES)[(offset + i) - BOOT_SECT_SIZE -
                     FAT_SIZE] = pbBuf[i];
         }


### PR DESCRIPTION
I'm not 100% sure that this is the correct way to fix this, but I don't think that the original code is correct.  The DIRECTORY_ENTRIES array is only 64 bytes in total size (2 x 32 byte structures), but using BLOCKSIZE here will attempt to write 512 bytes to it.  I would imagine the original code might work depending on how your operating system interacted with the USB device and how your compiler laid out the data structures in memory, but it definitely didn't work right for me on Windows 10 x64, using GCC provided by NXP with LPCXpresso.  Using the debugger, it was obvious that a number of unrelated variables were being corrupted when this code was run.  After making this change, it seems to work fine for me.
